### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: shish2k/shimmie2
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,8 @@ name: Tests
 on:
   push:
   pull_request:
-  schedule:
-    - cron: '0 2 * * 0' # Weekly on Sundays at 02:00
+  #schedule:
+  #  - cron: '0 2 * * 0' # Weekly on Sundays at 02:00
 
 jobs:
   format:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore